### PR TITLE
"SHA384 is not supported by your openssl extension" fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,13 @@ services:
       image: symfony-messaging-app
       volumes:
           - ./:/srv/app
-      entrypoint: ['bin/console', 'server:run', '0.0.0.0:8000']
       ports:
         - 8000:8000
       links:
           - rabbitmq
       depends_on:
         - rabbitmq
-          
+
   rabbitmq:
       image: rabbitmq:management
       ports:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,21 +12,15 @@ RUN pecl install amqp && echo "extension=amqp" > "/usr/local/etc/php/conf.d/amqp
 
 # Install composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV COMPOSER_HOME /tmp
-ENV COMPOSER_VERSION 1.7.3
-RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/b107d959a5924af895807021fcef4ffec5a76aa9/web/installer \
- && php -r " \
-    \$signature = '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061'; \
-    \$hash = hash('SHA384', file_get_contents('/tmp/installer.php')); \
-    if (!hash_equals(\$signature, \$hash)) { \
-        unlink('/tmp/installer.php'); \
-        echo 'Integrity check failed, installer is either corrupt or worse.' . PHP_EOL; \
-        exit(1); \
-    }" \
- && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
- && composer --ansi --version --no-interaction \
- && rm -rf /tmp/* /tmp/.htaccess
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php composer-setup.php
+RUN php -r "unlink('composer-setup.php');"
+RUN mv composer.phar /usr/local/bin/composer
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 8000
 
 WORKDIR /srv/app
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+composer install
+php bin/console server:run 0.0.0.0:8000
+
+exec "$@"

--- a/src/Controller/LuckyController.php
+++ b/src/Controller/LuckyController.php
@@ -11,6 +11,9 @@ class LuckyController
 {
     /**
      * @Route("/lucky/number")
+     * @param MessageBusInterface $bus
+     * @return Response
+     * @throws \Exception
      */
     public function number(MessageBusInterface $bus): Response
     {


### PR DESCRIPTION
Hi, I propose PR which fixes containers starting error:
```
Step 8/10 : RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/b107d959a5924af895807021fcef4ffec5a76aa9/web/installer  && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION}  && composer --ansi --version --no-interaction  && rm -rf /tmp/* /tmp/.htaccess
 ---> Running in 49b819c4783d
All settings correct for using Composer
SHA384 is not supported by your openssl extension
ERROR: Service 'app' failed to build: The command '/bin/sh -c curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/b107d959a5924af895807021fcef4ffec5a76aa9/web/installer  && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION}  && composer --ansi --version --no-interaction  && rm -rf /tmp/* /tmp/.htaccess' returned a non-zero code: 1
```